### PR TITLE
ui v2: improve filtering performances by limiting the amount of topics

### DIFF
--- a/uinext/src/node_modules/app/components/Map/MapboxglBase.svelte
+++ b/uinext/src/node_modules/app/components/Map/MapboxglBase.svelte
@@ -200,17 +200,8 @@
 	};
 
 	const setMapEvents = () => {
-		map
-		.on('move', () => {
+		map.on('move', () => {
 			updateProjection();
-		})
-		.on('resize', () => {
-			updateProjection();
-		})
-		.on('moveend', () => {
-			updateBbox();
-		})
-		.on('zoomend', () => {
 			updateBbox();
 		});
 	}

--- a/uinext/src/node_modules/app/stores/data.js
+++ b/uinext/src/node_modules/app/stores/data.js
@@ -95,6 +95,7 @@ export const _keyTopicIdValueOrgsCount = derived(
 			_.sorterDesc(getValue),
 			getKey
 		]),
+		_.take(100)
 	])
 );
 


### PR DESCRIPTION
closes #90

The slowness comes from rendering 12k topics in the topics bar chart,
so for now we just limit the amount of topics to speed up DX.